### PR TITLE
Tune workspace VolumeClaim sizes per environment

### DIFF
--- a/environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml
+++ b/environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml
@@ -27,4 +27,4 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 20Gi
+              storage: 6Gi

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-all-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-all-pipelinerun.yaml
@@ -28,4 +28,4 @@ spec:
           - ReadWriteOnce
           resources:
             requests:
-              storage: 20Gi
+              storage: 30Gi


### PR DESCRIPTION
- pipeline `environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml` fails on my laptop, for unavailability of 20G, reducing.
- pipeline `environments/overlays/operate-first/pipelineruns/okd-coreos-all-pipelinerun.yaml` fails on operatefirst at step cosa-buildextend, increasing to 30G