### PR TITLE
Fix artifacts permissions and edit link targets

### DIFF
--- a/manifests/tekton/tasks/base/cosa-build.yaml
+++ b/manifests/tekton/tasks/base/cosa-build.yaml
@@ -20,14 +20,15 @@ spec:
         cd /workspace/coreos
         cosa fetch
         cosa build ostree
-        
+
         # The rpms that were extracted from the artifacts image
         # are not present inside the container used to build the
         # extensions, however `rpm-ostree compose extensions`
         # will try to fetch metadata for all repos listed in
-        # {manifest,extensions}.yaml 
+        # both {manifest,extensions}.yaml 
         # TODO: Find a more elegant way to do this
-        sed -i 's/- artifacts//' "src/config/manifest.yaml"
+        sed -i 's/- artifacts//' $(readlink -f src/config/manifest.yaml)
+
         cosa build-extensions-container
 
   workspaces:

--- a/manifests/tekton/tasks/base/cosa-init.yaml
+++ b/manifests/tekton/tasks/base/cosa-init.yaml
@@ -45,12 +45,12 @@ spec:
         INFO
 
         cosa init \
-            --branch "$(params.branch)" \
-            --variant "$(params.variant)" \
-            "$(params.repo)"
+            --branch $(params.branch) \
+            --variant $(params.variant) \
+            $(params.repo)
 
         # Update symlinks for default manifests
-        cosa update-variant default scos
+        cosa update-variant default $(params.variant)
 
         # Move rpms into scope of COSA VM
         if [ -d "/workspace/rpms" ]; then
@@ -59,10 +59,10 @@ spec:
         fi
 
         # TODO: Upstream to openshift/os
-        sed -i 's/rhel-9-server-ose/artifacts/' "src/config/manifest-$(params.variant).yaml"
+        sed -i 's/rhel-9-server-ose/artifacts/' $(readlink -f src/config/manifest.yaml)
 
         # https://github.com/openshift/os/pull/1006
-        sed -i 's|file:///usr/share/distribution-gpg-keys/centos|https://www.centos.org/keys|g' "src/config/c9s.repo"
+        sed -i 's|file:///usr/share/distribution-gpg-keys/centos|https://www.centos.org/keys|g' src/config/c9s.repo
 
         # Get oc and hypershift from the yum repo in the artifacts image
         cat <<EOF >> src/config/c9s.repo

--- a/manifests/tekton/tasks/base/rpm-artifacts-copy.yaml
+++ b/manifests/tekton/tasks/base/rpm-artifacts-copy.yaml
@@ -17,6 +17,8 @@ spec:
 
         mkdir /workspace/rpms
         cp -irvf /srv/repo/*.rpm /workspace/rpms/
+        chmod 0777 /workspace/rpms/
+        chmod 0666 /workspace/rpms/*.rpm
 
   workspaces:
     - mountPath: /workspace


### PR DESCRIPTION
The artifacts are owned by root. In order for the builder user to move them around, let's open up the file permissions for them.