### PR TITLE
Pin kernel-5.14.0-168.el9.x86_64

### DIFF
--- a/manifests/tekton/tasks/base/cosa-init.yaml
+++ b/manifests/tekton/tasks/base/cosa-init.yaml
@@ -76,6 +76,9 @@ spec:
 
         EOF
 
+        # Pin kernel
+        sed -i "s/- kernel/- kernel-5.14.0-168.el9.x86_64/" src/config/manifest-c9s.yaml
+
   workspaces:
     - mountPath: /workspace
       name: ws


### PR DESCRIPTION
kernel-5.14.0-171.el9.x86_64 fails to boot in uefi-secure tests