### PR TITLE
Revert "Pin kernel-5.14.0-168.el9.x86_64"

### DIFF
--- a/manifests/tekton/tasks/base/cosa-init.yaml
+++ b/manifests/tekton/tasks/base/cosa-init.yaml
@@ -76,9 +76,6 @@ spec:
 
         EOF
 
-        # Pin kernel
-        sed -i "s/- kernel/- kernel-5.14.0-168.el9.x86_64/" src/config/manifest-c9s.yaml
-
   workspaces:
     - mountPath: /workspace
       name: ws


### PR DESCRIPTION
Reverts okd-project/okd-coreos-pipeline#18

The kernel is now pinned upstream in the os repository. See https://github.com/openshift/os/issues/1039



