### PR TITLE
tasks/cosa-init: Drop workaround for yum repo gpgkeys

### DIFF
--- a/manifests/tekton/tasks/base/cosa-init.yaml
+++ b/manifests/tekton/tasks/base/cosa-init.yaml
@@ -61,9 +61,6 @@ spec:
         # TODO: Upstream to openshift/os
         sed -i 's/rhel-9.*-server-ose.*/artifacts/' $(readlink -f src/config/manifest.yaml)
 
-        # https://github.com/openshift/os/pull/1006
-        sed -i 's|file:///usr/share/distribution-gpg-keys/centos|https://www.centos.org/keys|g' src/config/c9s.repo
-
         # tmp fix for replacing version labels in manifest
         sed -i "s/\"4.13\"/\"$(params.version)\"/g" $(readlink -f src/config/manifest.yaml)
         sed -i "s/\"413\.9./\"$(echo "$(params.version)" | sed 's/\.//')\.9./" $(readlink -f src/config/manifest.yaml)


### PR DESCRIPTION
With the inclusion of the `distribution-gpg-keys` rpm package in SCOS in https://github.com/openshift/os/pull/1032,
it is no longer required to fetch them from the internet.

Blocked by: https://github.com/openshift/os/pull/1032