### PR TITLE
Add versioning with shell utility and kustomize patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 my-secret.yaml
+xx00
+xx01

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ git clone https://github.com/okd-project/okd-coreos-pipeline.git
 
 Execute the following to start a pipelinerun locally:
 
+Change the ${VERSION} values in the relevant file (okd-coreos-all-pipelinerun.yaml or okd-coreos-build-pipelinerun.yaml) 
+
+Alternatively there is a utility script that you can use (execute-pipelinerun.sh)
+
+This allows the pipelinerun to execute using specific versions of openshift . It mitigates the need for adding various pipelinerun versioned files to this repo
+
 ```bash
 kubectl create \
     -n okd-coreos-pipeline \

--- a/environments/overlays/local/pipelineruns/kustomization.yaml
+++ b/environments/overlays/local/pipelineruns/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - okd-coreos-all-pipelinerun.yaml
+  - okd-coreos-build-pipelinerun.yaml
+
+patches:
+  - path: "patches/patch-version.yaml"
+    target:
+      kind: PipelineRun
+      name: okd-coreos-all-pipelinerun
+      group: tekton.dev
+      version: v1beta1
+
+  - path: "patches/patch-version.yaml"
+    target:
+      kind: PipelineRun
+      name: okd-coreos-build-pipelinerun
+      group: tekton.dev
+      version: v1beta1

--- a/environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml
+++ b/environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml
@@ -7,6 +7,7 @@ metadata:
     operator.tekton.dev/prune.resources: "taskrun, pipelinerun"
     operator.tekton.dev/prune.keep: "1"
     operator.tekton.dev/prune.strategy: "keep"
+  name: okd-coreos-all-pipelinerun
 spec:
   params:
     - name: repo
@@ -14,11 +15,11 @@ spec:
     - name: branch
       value: "master"
     - name: variant
-      value: "scos"     
+      value: "scos"
     - name: version
-      value: "4.12"
+      value: "${VERSION}"
     - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/4.12:artifacts"
+      value: "registry.ci.openshift.org/origin/${VERSION}:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/overlays/local/pipelineruns/okd-coreos-build-pipelinerun.yaml
+++ b/environments/overlays/local/pipelineruns/okd-coreos-build-pipelinerun.yaml
@@ -7,6 +7,7 @@ metadata:
     operator.tekton.dev/prune.resources: "taskrun, pipelinerun"
     operator.tekton.dev/prune.keep: "1"
     operator.tekton.dev/prune.strategy: "keep"
+  name: okd-coreos-build-pipelinerun
 spec:
   params:
     - name: repo
@@ -16,9 +17,9 @@ spec:
     - name: variant
       value: "scos"     
     - name: version
-      value: "4.12"
+      value: "${VERSION}"
     - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/4.12:artifacts"
+      value: "registry.ci.openshift.org/origin/${VERSION}:artifacts"
   pipelineRef:
     name: okd-coreos-build
   workspaces:

--- a/environments/overlays/local/pipelineruns/patches/patch-version.yaml
+++ b/environments/overlays/local/pipelineruns/patches/patch-version.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: "/spec/params/3/value"
+  value:
+    "4.13"
+
+- op: replace
+  path: "/spec/params/4/value"
+  value:
+    "registry.ci.openshift.org/origin/4.13:artifacts"

--- a/environments/overlays/operate-first/pipelineruns/kustomization.yaml
+++ b/environments/overlays/operate-first/pipelineruns/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - okd-coreos-all-pipelinerun.yaml
+  - okd-coreos-build-pipelinerun.yaml
+namespace: okd-team
+
+patches:
+  - path: "patches/patch-version.yaml"
+    target:
+      kind: PipelineRun
+      name: okd-coreos-all-pipelinerun
+      group: tekton.dev
+      version: v1beta1
+
+  - path: "patches/patch-version.yaml"
+    target:
+      kind: PipelineRun
+      name: okd-coreos-build-pipelinerun
+      group: tekton.dev
+      version: v1beta1

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-all-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-all-pipelinerun.yaml
@@ -7,6 +7,7 @@ metadata:
     operator.tekton.dev/prune.resources: "taskrun, pipelinerun"
     operator.tekton.dev/prune.keep: "1"
     operator.tekton.dev/prune.strategy: "keep"
+  name: okd-coreos-all-pipelinerun
 spec:
   params:
     - name: repo
@@ -14,11 +15,11 @@ spec:
     - name: branch
       value: "master"
     - name: variant
-      value: "scos"     
+      value: "scos"
     - name: version
-      value: "4.12"
+      value: "${VERSION}"
     - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/4.12:artifacts"
+      value: "registry.ci.openshift.org/origin/${VERSION}:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-build-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-build-pipelinerun.yaml
@@ -7,6 +7,7 @@ metadata:
     operator.tekton.dev/prune.resources: "taskrun, pipelinerun"
     operator.tekton.dev/prune.keep: "1"
     operator.tekton.dev/prune.strategy: "keep"
+  name: okd-coreos-build-pipelinerun
 spec:
   params:
     - name: repo
@@ -14,11 +15,11 @@ spec:
     - name: branch
       value: "master"
     - name: variant
-      value: "scos"     
+      value: "scos"
     - name: version
-      value: "4.12"
+      value: "${VERSION}"
     - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/4.12:artifacts"
+      value: "registry.ci.openshift.org/origin/${VERSION}:artifacts"
   pipelineRef:
     name: okd-coreos-build
   workspaces:

--- a/environments/overlays/operate-first/pipelineruns/patches/patch-version.yaml
+++ b/environments/overlays/operate-first/pipelineruns/patches/patch-version.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: "/spec/params/3/value"
+  value:
+    "${VERSION}"
+
+- op: replace
+  path: "/spec/params/4/value"
+  value:
+    "registry.ci.openshift.org/origin/${VERSION}:artifacts"

--- a/execute-pipelinerun.sh
+++ b/execute-pipelinerun.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+
+set -o pipefail
+
+if [ "$#" -lt 3 ]
+then
+  echo " "
+  echo -e "\033[0;95musage   execute-pipelinerun.sh <operate-first|local> <ocp-version> <all|build>>\033[0m"
+  echo -e "\033[0;93mexample execute-pipelinerun.sh local 4.13 all\033[0m"
+  echo " "
+  exit 1
+fi
+
+
+echo -e "\033[0;96mensure your are logged into the $1 cluster\033[0m"
+
+cat << EOF > environments/overlays/local/pipelineruns/patches/patch-version.yaml
+- op: replace
+  path: "/spec/params/3/value"
+  value:
+    "$2"
+
+- op: replace
+  path: "/spec/params/4/value"
+  value:
+    "registry.ci.openshift.org/origin/$2:artifacts"
+EOF
+
+echo -e "\033[0;95mdeploying to $1 with version $2 using the $3 pipelinerun file\033[0m"
+echo " "
+
+if [ "$3" == "build" ];
+then
+    kustomize build environments/overlays/$1/pipelineruns/ | csplit - '/---$/' && cat xx01 | awk FNR!=1 | kubectl apply -f -
+else
+    kustomize build environments/overlays/$1/pipelineruns/ | csplit - '/---$/' && cat xx00 | kubectl apply -f - 
+fi
+


### PR DESCRIPTION
Added a  shell script to allow for ocp versioning when executing a pipelinerun.

It's a bit of an overkill as I could have done something like

`sed 's/${VERSION}/4.14/g' environments/overlays/local/pipelineruns/okd-coreos-all-pipelinerun.yaml | kubectl -n okd-team apply -f -`