### PR TITLE
tekton tasks: mount workspace to /srv

### DIFF
--- a/manifests/tekton/tasks/base/cosa-build-baseos.yaml
+++ b/manifests/tekton/tasks/base/cosa-build-baseos.yaml
@@ -19,11 +19,11 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        cd /workspace/coreos
+        cd /srv/coreos
 
         cosa fetch
         cosa build ostree
 
   workspaces:
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws

--- a/manifests/tekton/tasks/base/cosa-build-extensions.yaml
+++ b/manifests/tekton/tasks/base/cosa-build-extensions.yaml
@@ -20,8 +20,8 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        cd /workspace/coreos
-        
+        cd /srv/coreos
+
         # The rpms that were extracted from the artifacts image
         # are not present inside the container used to build the
         # extensions, however `rpm-ostree compose extensions`
@@ -33,5 +33,5 @@ spec:
         cosa build-extensions-container
 
   workspaces:
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws

--- a/manifests/tekton/tasks/base/cosa-buildextend.yaml
+++ b/manifests/tekton/tasks/base/cosa-buildextend.yaml
@@ -20,11 +20,11 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        cd /workspace/coreos
+        cd /srv/coreos
         cosa buildextend-metal4k
         cosa buildextend-metal
         cosa buildextend-live
 
   workspaces:
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws

--- a/manifests/tekton/tasks/base/cosa-init.yaml
+++ b/manifests/tekton/tasks/base/cosa-init.yaml
@@ -30,8 +30,8 @@ spec:
         #!/usr/bin/env bash 
         set -euxo pipefail 
 
-        mkdir -p /workspace/coreos
-        cd /workspace/coreos
+        mkdir -p /srv/coreos
+        cd /srv/coreos
 
         cat << INFO
         Initializing coreos-assembler:
@@ -53,9 +53,9 @@ spec:
         cosa update-variant default $(params.variant)
 
         # Move rpms into scope of COSA VM
-        if [ -d "/workspace/rpms" ]; then
-          mv /workspace/rpms /workspace/coreos/
-          createrepo_c /workspace/coreos/rpms
+        if [ -d "/srv/rpms" ]; then
+          mv /srv/rpms /srv/coreos/
+          createrepo_c /srv/coreos/rpms
         fi
 
         # TODO: Upstream to openshift/os
@@ -69,7 +69,7 @@ spec:
 
         [artifacts]
         name=OKD RPM artifacts
-        baseurl=file:///workspace/coreos/rpms/
+        baseurl=file:///srv/coreos/rpms/
         repo_gpgcheck=0
         gpgcheck=0
         enabled=1
@@ -77,5 +77,5 @@ spec:
         EOF
 
   workspaces:
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws

--- a/manifests/tekton/tasks/base/cosa-test.yaml
+++ b/manifests/tekton/tasks/base/cosa-test.yaml
@@ -19,10 +19,10 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        cd /workspace/coreos
+        cd /srv/coreos
         cosa buildextend-qemu
         cosa kola --basic-qemu-scenarios
 
   workspaces:
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws

--- a/manifests/tekton/tasks/base/cosa-upload.yaml
+++ b/manifests/tekton/tasks/base/cosa-upload.yaml
@@ -28,7 +28,7 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        cd /workspace/coreos
+        cd /srv/coreos
         cosa push-container --authfile=/registry-credentials/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name):$(params.tag)-$(uname -m)
         if [[ "$(params.tag-latest)" == "true" ]]; then
           cosa push-container --authfile=/registry-credentials/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name)
@@ -37,5 +37,5 @@ spec:
   workspaces:
     - mountPath: /registry-credentials
       name: regcred
-    - mountPath: /workspace
+    - mountPath: /srv
       name: ws


### PR DESCRIPTION
`cosa buildextend-live` script bind-mounts current directory into the  VM, so workdir path must exist in the VM, otherwise it would attempt to  create a new dir for it.

This fixes 
```
mkdir: cannot create directory 
'/sysroot/ostree/deploy/scos/deploy/deadbeef//workspace': Read-only file 
system
```
 in `cosa-buildextend` task