### PR TITLE
Add delete pipelinerun cronjob

### DIFF
--- a/environments/overlays/operate-first/kustomization.yaml
+++ b/environments/overlays/operate-first/kustomization.yaml
@@ -4,4 +4,7 @@ bases:
   - ../../../manifests/tekton/rbac/base
   - ../../../manifests/tekton/tasks/base
   - ../../../manifests/tekton/pipelines/base
+  - ../../../manifests/tekton/configmaps/base
+  - ../../../manifests/tekton/cronjobs/base
+
 namespace: okd-team

--- a/manifests/tekton/configmaps/base/delete-script-configmap.yaml
+++ b/manifests/tekton/configmaps/base/delete-script-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: delete-script
+  namespace: okd-team
+data:
+  delete-script.sh: |
+    #!/usr/bin/env bash
+    set -xuo pipefail
+    PRLIST=$(oc get pipelineruns -n okd-team | grep okd-coreos-all | awk '{print $1}')
+    for i in ${PRLIST}; do echo deleting ${i}; oc delete pipelinerun ${i} -n okd-team; done

--- a/manifests/tekton/configmaps/base/kustomization.yaml
+++ b/manifests/tekton/configmaps/base/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - delete-script-configmap.yaml

--- a/manifests/tekton/cronjobs/base/delete-pr-conjob.yaml
+++ b/manifests/tekton/cronjobs/base/delete-pr-conjob.yaml
@@ -1,0 +1,39 @@
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: daily-delete-pr-job
+  namespace: okd-team
+spec:
+  schedule: 0 20 * * *
+  concurrencyPolicy: Allow
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: daily-delete-prjob
+              image: image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest 
+              command: ["/bin/sh","-c","/tmp/delete-script.sh"]
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 250Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              volumeMounts:
+              - mountPath: /tmp
+                name: delete-script
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          volumes:
+          - name: delete-script
+            configMap:
+              name: delete-script
+              defaultMode: 493
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/manifests/tekton/cronjobs/base/kustomization.yaml
+++ b/manifests/tekton/cronjobs/base/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - delete-pr-cronjob.yaml

--- a/manifests/tekton/util/base/debug-pod.yaml
+++ b/manifests/tekton/util/base/debug-pod.yaml
@@ -1,0 +1,31 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: debug-pod
+  namespace: okd-team
+spec:
+  containers:
+    - name: debug-pod-container
+      image: image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest 
+      command: ["/bin/sh","-c","/tmp/delete-script.sh"]
+      resources:
+        limits:
+          cpu: 200m
+          memory: 250Mi
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      imagePullPolicy: Always
+      volumeMounts:
+      - mountPath: /tmp
+        name: delete-script
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  volumes:
+  - name: delete-script
+    configMap:
+      name: delete-script
+      defaultMode: 493
+


### PR DESCRIPTION
This allows us to clean up pipelineruns and associated persistent volume claims. 

With this in place the limitations set by operate-first on disk space are mitigated and will then execute the daily build cronjob (for coreos-build-all) without the pvc error (pv, pvc resource limits).

The cronjob will run 12 hours after the daily cores-build-all job , giving us ample time to view logs and investigate any problems
 