### PR TITLE
Support fetching/uploading builds to S3

### DIFF
--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
@@ -36,6 +36,8 @@ spec:
     - name: registry-credentials
       secret:
         secretName: okd-scos-robot-pull-secret
+    - name: s3-credentials
+      emptyDir: {}
     - name: shared-workspace
       volumeClaimTemplate:
         spec:

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
@@ -37,7 +37,8 @@ spec:
       secret:
         secretName: okd-scos-robot-pull-secret
     - name: s3-credentials
-      emptyDir: {}
+      secret:
+        secretName: okd-scos-aws-config
     - name: shared-workspace
       volumeClaimTemplate:
         spec:

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
@@ -27,6 +27,12 @@ spec:
       value: "centos-stream-coreos-9-extensions"
     - name: tag-latest
       value: "false"
+    - name: s3-bucket-name
+      value: ""
+    - name: s3-endpoint-url
+      value: ""
+    - name: s3-aws-config-file
+      value: ""
   pipelineRef:
     name: okd-coreos-all
   timeouts:
@@ -36,6 +42,8 @@ spec:
     - name: registry-credentials
       secret:
         secretName: okd-scos-robot-pull-secret
+    - name: s3-credentials
+      emptyDir: {}
     - name: shared-workspace
       volumeClaimTemplate:
         spec:

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-build-4.12-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-build-4.12-pipelinerun.yaml
@@ -22,6 +22,8 @@ spec:
   pipelineRef:
     name: okd-coreos-build
   workspaces:
+    - name: s3-credentials
+      emptyDir: {}
     - name: shared-workspace
       volumeClaimTemplate:
         spec:

--- a/environments/overlays/operate-first/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
+++ b/environments/overlays/operate-first/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
@@ -22,6 +22,8 @@ spec:
   pipelineRef:
     name: okd-coreos-build
   workspaces:
+    - name: s3-credentials
+      emptyDir: {}
     - name: shared-workspace
       volumeClaimTemplate:
         spec:

--- a/manifests/tekton/pipelines/base/okd-coreos-all.yaml
+++ b/manifests/tekton/pipelines/base/okd-coreos-all.yaml
@@ -31,6 +31,15 @@ spec:
     - name: tag-latest
       default: "false"
       type: string
+    - name: s3-bucket-name
+      default: ""
+      type: string
+    - name: s3-endpoint-url
+      default: ""
+      type: string
+    - name: s3-aws-config-file
+      default: ""
+      type: string
   tasks:
     - name: rpm-artifacts-copy
       params:
@@ -66,9 +75,18 @@ spec:
       taskRef:
         kind: Task
         name: cosa-build-baseos
+      params:
+        - name: bucket-name
+          value: $(params.s3-bucket-name)
+        - name: endpoint-url
+          value: $(params.s3-endpoint-url)
+        - name: aws-config-file
+          value: $(params.s3-aws-config-file)
       workspaces:
         - name: ws
           workspace: shared-workspace
+        - name: s3creds
+          workspace: s3-credentials
     - name: cosa-test
       runAfter:
         - cosa-build-baseos
@@ -83,7 +101,7 @@ spec:
         - cosa-test
       taskRef:
         kind: Task
-        name: cosa-upload
+        name: cosa-push-container
       params:
         - name: target-registry
           value: $(params.target-registry)
@@ -114,7 +132,7 @@ spec:
         - cosa-build-extensions
       taskRef:
         kind: Task
-        name: cosa-upload
+        name: cosa-push-container
       params:
         - name: target-registry
           value: $(params.target-registry)
@@ -140,6 +158,25 @@ spec:
       workspaces:
         - name: ws
           workspace: shared-workspace
+    - name: cosa-upload-liveiso
+      runAfter:
+        - cosa-buildextend
+      taskRef:
+        kind: Task
+        name: cosa-upload-s3
+      params:
+        - name: bucket-name
+          value: $(params.s3-bucket-name)
+        - name: endpoint-url
+          value: $(params.s3-endpoint-url)
+        - name: aws-config-file
+          value: $(params.s3-aws-config-file)
+      workspaces:
+        - name: s3creds
+          workspace: s3-credentials
+        - name: ws
+          workspace: shared-workspace
   workspaces:
     - name: registry-credentials
+    - name: s3-credentials
     - name: shared-workspace

--- a/manifests/tekton/pipelines/base/okd-coreos-build.yaml
+++ b/manifests/tekton/pipelines/base/okd-coreos-build.yaml
@@ -19,6 +19,15 @@ spec:
     - default: "registry.ci.openshift.org/origin/4.12:artifacts"
       name: rpm-artifacts-image
       type: string
+    - name: s3-bucket-name
+      default: ""
+      type: string
+    - name: s3-endpoint-url
+      default: ""
+      type: string
+    - name: s3-aws-config-file
+      default: ""
+      type: string
   tasks:
     - name: rpm-artifacts-copy
       params:
@@ -51,6 +60,13 @@ spec:
     - name: cosa-build-baseos
       runAfter:
         - cosa-init
+      params:
+        - name: bucket-name
+          value: $(params.s3-bucket-name)
+        - name: endpoint-url
+          value: $(params.s3-endpoint-url)
+        - name: aws-config-file
+          value: $(params.s3-aws-config-file)
       taskRef:
         kind: Task
         name: cosa-build-baseos
@@ -68,3 +84,4 @@ spec:
           workspace: shared-workspace
   workspaces:
     - name: shared-workspace
+    - name: s3-credentials

--- a/manifests/tekton/tasks/base/cosa-build-extensions.yaml
+++ b/manifests/tekton/tasks/base/cosa-build-extensions.yaml
@@ -26,7 +26,7 @@ spec:
         # are not present inside the container used to build the
         # extensions, however `rpm-ostree compose extensions`
         # will try to fetch metadata for all repos listed in
-        # both {manifest,extensions}.yaml 
+        # both {manifest,extensions}.yaml
         # TODO: Find a more elegant way to do this
         sed -i 's/- artifacts//' $(readlink -f src/config/manifest.yaml)
 

--- a/manifests/tekton/tasks/base/cosa-push-container.yaml
+++ b/manifests/tekton/tasks/base/cosa-push-container.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: cosa-upload
+  name: cosa-push-container
 spec:
   params:
     - name: target-registry

--- a/manifests/tekton/tasks/base/cosa-upload-s3.yaml
+++ b/manifests/tekton/tasks/base/cosa-upload-s3.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: cosa-build-baseos
+  name: cosa-upload-s3
 spec:
   params:
     - name: bucket-name
@@ -15,34 +15,25 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
-      name: fetch-and-build-baseos
-      resources:
-        limits:
-          cpu: 1000m
-          devices.kubevirt.io/kvm: '1'
-          memory: 4Gi
-        requests:
-          cpu: 1000m
-          devices.kubevirt.io/kvm: '1'
-          memory: 4Gi
+      name: upload-image
+      onError: continue
+      resources: {}
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail
 
         cd /srv/coreos
-
         if [[ -z "$(params.endpoint-url)" || -z "$(params.aws-config-file)" || -z "$(params.bucket-name)" ]]; then
-          echo "Skipping buildfetch from S3 - bucket params not set"
-        else
-          cosa buildfetch \
-          --url=s3://$(params.bucket-name) \
-          --aws-config-file=/s3-credentials/$(params.aws-config-file)
+          echo "Skipping upload to S3 - bucket params not set"
+          return 0
         fi
-        cosa fetch
-        cosa build ostree
+        cosa buildupload s3 \
+          --endpoint-url=$(params.endpoint-url) \
+          --aws-config-file=/s3-credentials/$(params.aws-config-file) \
+          $(params.bucket-name)
 
   workspaces:
-    - mountPath: /srv
-      name: ws
     - mountPath: /s3-credentials
       name: s3creds
+    - mountPath: /srv
+      name: ws

--- a/manifests/tekton/tasks/base/kustomization.yaml
+++ b/manifests/tekton/tasks/base/kustomization.yaml
@@ -3,6 +3,7 @@ bases:
   - cosa-build-baseos.yaml
   - cosa-build-extensions.yaml
   - cosa-buildextend.yaml
-  - cosa-upload.yaml
+  - cosa-push-container.yaml
   - cosa-test.yaml
+  - cosa-upload-s3.yaml
   - rpm-artifacts-copy.yaml


### PR DESCRIPTION
This adds buildfetch step in cosa-build-baseos step to fetch previous build metadata from S3. cosa-upload-s3 task is added to upload build artifacts to S3.

S3 credentials are stored in the secret, similar to regcreds. If any of S3 parameters is unset buildfetch/upload are skipped