### PR TITLE
tekton/cosa-init: Remove call to 'cosa update-variant'

### DIFF
--- a/base/tekton.dev/pipelines/okd-coreos-all.yaml
+++ b/base/tekton.dev/pipelines/okd-coreos-all.yaml
@@ -121,6 +121,9 @@ spec:
     - name: cosa-build-extensions
       runAfter:
         - cosa-test
+      params:
+        - name: variant
+          value: $(params.variant)
       taskRef:
         kind: Task
         name: cosa-build-extensions

--- a/base/tekton.dev/pipelines/okd-coreos-build.yaml
+++ b/base/tekton.dev/pipelines/okd-coreos-build.yaml
@@ -87,6 +87,9 @@ spec:
     - name: cosa-build-extensions
       runAfter:
         - cosa-test
+      params:
+        - name: variant
+          value: $(params.variant)
       taskRef:
         kind: Task
         name: cosa-build-extensions

--- a/base/tekton.dev/tasks/cosa-build-extensions.yaml
+++ b/base/tekton.dev/tasks/cosa-build-extensions.yaml
@@ -3,6 +3,10 @@ kind: Task
 metadata:
   name: cosa-build-extensions
 spec:
+  params:
+    - description: The CoreOS variant
+      name: variant
+      type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
       name: build-extensions-container
@@ -28,7 +32,7 @@ spec:
         # will try to fetch metadata for all repos listed in
         # both {manifest,extensions}.yaml
         # TODO: Find a more elegant way to do this
-        sed -i 's/- artifacts//' $(readlink -f src/config/manifest.yaml)
+        sed -i 's/- artifacts//' $(readlink -f src/config/manifest-$(params.variant).yaml)
 
         cosa build-extensions-container
 

--- a/base/tekton.dev/tasks/cosa-init.yaml
+++ b/base/tekton.dev/tasks/cosa-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: cosa-init 
+  name: cosa-init
 spec:
   params:
     - description: The manifest repo URL
@@ -27,21 +27,21 @@ spec:
           devices.kubevirt.io/kvm: '1'
           memory: 4Gi
       script: |
-        #!/usr/bin/env bash 
-        set -euxo pipefail 
+        #!/usr/bin/env bash
+        set -euxo pipefail
 
         mkdir -p /srv/coreos
         cd /srv/coreos
 
         cat << INFO
         Initializing coreos-assembler:
-        
+
         Manifest repo:  $(params.repo)
         Branch:         $(params.branch)
 
         OKD version:    $(params.version)
         CoreOS variant: $(params.variant)
-        
+
         INFO
 
         cosa init \

--- a/base/tekton.dev/tasks/cosa-init.yaml
+++ b/base/tekton.dev/tasks/cosa-init.yaml
@@ -49,9 +49,6 @@ spec:
             --variant $(params.variant) \
             $(params.repo)
 
-        # Update symlinks for default manifests
-        cosa update-variant default $(params.variant)
-
         # Move rpms into scope of COSA VM
         if [ -d "/srv/rpms" ]; then
           mv /srv/rpms /srv/coreos/
@@ -59,11 +56,11 @@ spec:
         fi
 
         # TODO: Upstream to openshift/os
-        sed -i 's/rhel-9.*-server-ose.*/artifacts/' $(readlink -f src/config/manifest.yaml)
+        sed -i 's/rhel-9.*-server-ose.*/artifacts/' $(readlink -f src/config/manifest-$(params.variant).yaml)
 
         # tmp fix for replacing version labels in manifest
-        sed -i "s/\"4.13\"/\"$(params.version)\"/g" $(readlink -f src/config/manifest.yaml)
-        sed -i "s/\"413\.9./\"$(echo "$(params.version)" | sed 's/\.//')\.9./" $(readlink -f src/config/manifest.yaml)
+        sed -i "s/\"4.13\"/\"$(params.version)\"/g" $(readlink -f src/config/manifest-$(params.variant).yaml)
+        sed -i "s/\"413\.9./\"$(echo "$(params.version)" | sed 's/\.//')\.9./" $(readlink -f src/config/manifest-$(params.variant).yaml)
 
         # Get oc and hypershift from the yum repo in the artifacts image
         cat <<EOF >> src/config/c9s.repo


### PR DESCRIPTION
We have fixed all issues with variants build in the extension code path so this is no longer needed anymore.