### PR TITLE
Wire up S3 pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,5 @@ tkn pipelinerun logs -f \
 
 ## TODO
 
-* Push the image artifacts to S3 bucket
 * Build and test images for more platforms
 * Control the previous build, so that we build when needed

--- a/base/tekton.dev/pipelines/okd-coreos-all.yaml
+++ b/base/tekton.dev/pipelines/okd-coreos-all.yaml
@@ -38,7 +38,7 @@ spec:
       default: ""
       type: string
     - name: s3-aws-config-file
-      default: ""
+      default: "credentials"
       type: string
   tasks:
     - name: rpm-artifacts-copy
@@ -96,9 +96,29 @@ spec:
       workspaces:
         - name: ws
           workspace: shared-workspace
-    - name: cosa-upload-baseos
+    - name: cosa-build-extensions
       runAfter:
         - cosa-test
+      params:
+        - name: variant
+          value: $(params.variant)
+      taskRef:
+        kind: Task
+        name: cosa-build-extensions
+      workspaces:
+        - name: ws
+          workspace: shared-workspace
+    - name: cosa-buildextend
+      runAfter:
+        - cosa-test
+      taskRef:
+        kind: Task
+        name: cosa-buildextend
+      workspaces:
+        - name: ws
+          workspace: shared-workspace
+  finally:
+    - name: cosa-upload-baseos
       taskRef:
         kind: Task
         name: cosa-push-container
@@ -118,21 +138,7 @@ spec:
           workspace: registry-credentials
         - name: ws
           workspace: shared-workspace
-    - name: cosa-build-extensions
-      runAfter:
-        - cosa-test
-      params:
-        - name: variant
-          value: $(params.variant)
-      taskRef:
-        kind: Task
-        name: cosa-build-extensions
-      workspaces:
-        - name: ws
-          workspace: shared-workspace
     - name: cosa-upload-extensions
-      runAfter:
-        - cosa-build-extensions
       taskRef:
         kind: Task
         name: cosa-push-container
@@ -152,18 +158,7 @@ spec:
           workspace: registry-credentials
         - name: ws
           workspace: shared-workspace
-    - name: cosa-buildextend
-      runAfter:
-        - cosa-test
-      taskRef:
-        kind: Task
-        name: cosa-buildextend
-      workspaces:
-        - name: ws
-          workspace: shared-workspace
-    - name: cosa-upload-liveiso
-      runAfter:
-        - cosa-buildextend
+    - name: cosa-upload-bootimages
       taskRef:
         kind: Task
         name: cosa-upload-s3

--- a/base/tekton.dev/tasks/cosa-build-baseos.yaml
+++ b/base/tekton.dev/tasks/cosa-build-baseos.yaml
@@ -11,7 +11,7 @@ spec:
       default: ""
       type: string
     - name: aws-config-file
-      default: ""
+      default: "credentials"
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
@@ -31,12 +31,12 @@ spec:
 
         cd /srv/coreos
 
-        if [[ -z "$(params.endpoint-url)" || -z "$(params.aws-config-file)" || -z "$(params.bucket-name)" ]]; then
+        if [[ -z "$(params.endpoint-url)" || ! -f "$(workspaces.s3creds.path)/$(params.aws-config-file)" || -z "$(params.bucket-name)" ]]; then
           echo "Skipping buildfetch from S3 - bucket params not set"
         else
           cosa buildfetch \
-          --url=s3://$(params.bucket-name) \
-          --aws-config-file=/s3-credentials/$(params.aws-config-file)
+          --url=s3://$(params.bucket-name)/builds \
+          --aws-config-file=$(workspaces.s3creds.path)/$(params.aws-config-file)
         fi
         cosa fetch
         cosa build ostree
@@ -44,5 +44,4 @@ spec:
   workspaces:
     - mountPath: /srv
       name: ws
-    - mountPath: /s3-credentials
-      name: s3creds
+    - name: s3creds

--- a/base/tekton.dev/tasks/cosa-push-container.yaml
+++ b/base/tekton.dev/tasks/cosa-push-container.yaml
@@ -28,13 +28,12 @@ spec:
         set -euxo pipefail
 
         cd /srv/coreos
-        cosa push-container --authfile=/registry-credentials/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name):$(params.tag)-$(uname -m)
+        cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name):$(params.tag)-$(uname -m)
         if [[ "$(params.tag-latest)" == "true" ]]; then
-          cosa push-container --authfile=/registry-credentials/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name)
+          cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name)
         fi
 
   workspaces:
-    - mountPath: /registry-credentials
-      name: regcred
+    - name: regcred
     - mountPath: /srv
       name: ws

--- a/base/tekton.dev/tasks/cosa-upload-s3.yaml
+++ b/base/tekton.dev/tasks/cosa-upload-s3.yaml
@@ -11,28 +11,29 @@ spec:
       default: ""
       type: string
     - name: aws-config-file
-      default: ""
+      default: "credentials"
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
       name: upload-image
+      onError: continue
       resources: {}
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail
 
         cd /srv/coreos
-        if [[ -z "$(params.endpoint-url)" || -z "$(params.aws-config-file)" || -z "$(params.bucket-name)" ]]; then
+        if [[ -z "$(params.endpoint-url)" || ! -f "$(workspaces.s3creds.path)/$(params.aws-config-file)" || -z "$(params.bucket-name)" ]]; then
           echo "Skipping upload to S3 - bucket params not set"
           exit 0
         fi
         cosa buildupload s3 \
           --endpoint-url=$(params.endpoint-url) \
-          --aws-config-file=/s3-credentials/$(params.aws-config-file) \
-          $(params.bucket-name)
+          --aws-config-file=$(workspaces.s3creds.path)/$(params.aws-config-file) \
+          --acl=bucket-owner-full-control \
+          $(params.bucket-name)/builds
 
   workspaces:
-    - mountPath: /s3-credentials
-      name: s3creds
+    - name: s3creds
     - mountPath: /srv
       name: ws

--- a/base/triggers.tekton.dev/triggertemplates/okd-coreos-all.yaml
+++ b/base/triggers.tekton.dev/triggertemplates/okd-coreos-all.yaml
@@ -23,11 +23,11 @@ spec:
   - name: tag-latest
     default: "false"
   - name: s3-bucket-name
-    default: ""
+    default: "okd-scos"
   - name: s3-endpoint-url
-    default: ""
+    default: "https://okd-scos.s3.amazonaws.com/"
   - name: s3-aws-config-file
-    default: ""
+    default: "credentials"
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun

--- a/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
+++ b/overlays/operate-first/pipelineruns/okd-coreos-all-4.12-pipelinerun.yaml
@@ -27,6 +27,10 @@ spec:
       value: "centos-stream-coreos-9-extensions"
     - name: tag-latest
       value: "true"
+    - name: s3-bucket-name
+      value: "okd-scos"
+    - name: s3-endpoint-url
+      value: "https://okd-scos.s3.amazonaws.com/"
   pipelineRef:
     name: okd-coreos-all
   timeouts:

--- a/overlays/operate-first/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
+++ b/overlays/operate-first/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
@@ -28,11 +28,9 @@ spec:
     - name: tag-latest
       value: "false"
     - name: s3-bucket-name
-      value: ""
+      value: "okd-scos"
     - name: s3-endpoint-url
-      value: ""
-    - name: s3-aws-config-file
-      value: ""
+      value: "https://okd-scos.s3.amazonaws.com/"
   pipelineRef:
     name: okd-coreos-all
   timeouts:


### PR DESCRIPTION
Follow up to https://github.com/okd-project/okd-coreos-pipeline/pull/30

:warning: this is already deployed to smaug!

Uploading the build still fails, possibly due to some missing permissions on the AWS side:
```
+ cd /srv/coreos
+ [[ -z https://okd-scos.s3.amazonaws.com/ ]]
+ [[ ! -f /workspace/s3creds/credentials ]]
+ [[ -z okd-scos ]]
+ cosa buildupload s3 --endpoint-url=https://okd-scos.s3.amazonaws.com/ --aws-config-file=/workspace/s3creds/credentials --acl=bucket-owner-full-control okd-scos/builds
2023-02-22 23:17:35,163 INFO - Credentials found in config file: /workspace/s3creds/credentials
NOTICE: No tmp/builds-source.txt file; uploading without buildfetch?
Targeting build: 412.9.202302222244-0
Checking if bucket 'okd-scos' has key 'builds/412.9.202302222244-0/x86_64/scos-412.9.202302222244-0-ostree.x86_64.ociarchive'
Uploading builds/412.9.202302222244-0/x86_64/scos-412.9.202302222244-0-ostree.x86_64.ociarchive to s3://okd-scos/builds/412.9.202302222244-0/x86_64/scos-412.9.202302222244-0-ostree.x86_64.ociarchive {'ContentType': 'application/octet-stream'}
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/boto3/s3/transfer.py", line 292, in upload_file
    future.result()
  File "/usr/lib/python3.11/site-packages/s3transfer/futures.py", line 103, in result
    return self._coordinator.result()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/s3transfer/futures.py", line 266, in result
    raise self._exception
  File "/usr/lib/python3.11/site-packages/s3transfer/tasks.py", line 139, in __call__
    return self._execute_main(kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/s3transfer/tasks.py", line 162, in _execute_main
    return_value = self._main(**kwargs)
                   ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/s3transfer/tasks.py", line 348, in _main
    response = client.create_multipart_upload(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the CreateMultipartUpload operation: Access Denied

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/coreos-assembler/cmd-buildupload", line 242, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/coreos-assembler/cmd-buildupload", line 30, in main
    args.func(args)
  File "/usr/lib/coreos-assembler/cmd-buildupload", line 83, in cmd_upload_s3
    s3_upload_build(s3_client, args, builds.get_build_dir(args.build, arch),
  File "/usr/lib/coreos-assembler/cmd-buildupload", line 163, in s3_upload_build
    s3_copy(s3_client, path, bucket, s3_path,
  File "/usr/lib/python3.11/site-packages/tenacity/__init__.py", line 324, in wrapped_f
    return self(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/tenacity/__init__.py", line 404, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/tenacity/__init__.py", line 349, in iter
    return fut.result()
           ^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.11/site-packages/tenacity/__init__.py", line 407, in __call__
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/coreos-assembler/cmd-buildupload", line 238, in s3_copy
    s3_client.upload_file(Filename=src, Bucket=bucket, Key=key, ExtraArgs=upload_args)
  File "/usr/lib/python3.11/site-packages/boto3/s3/inject.py", line 143, in upload_file
    return transfer.upload_file(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/boto3/s3/transfer.py", line 298, in upload_file
    raise S3UploadFailedError(
boto3.exceptions.S3UploadFailedError: Failed to upload builds/412.9.202302222244-0/x86_64/scos-412.9.202302222244-0-ostree.x86_64.ociarchive to okd-scos/builds/412.9.202302222244-0/x86_64/scos-412.9.202302222244-0-ostree.x86_64.ociarchive: An error occurred (AccessDenied) when calling the CreateMultipartUpload operation: Access Denied
error: failed to execute cmd-buildupload: exit status 1
``` 