### PR TITLE
cosa-init: Use openvswitch2.17 for 4.12, and temporarily for 4.13 too

### DIFF
--- a/base/tekton.dev/tasks/cosa-init.yaml
+++ b/base/tekton.dev/tasks/cosa-init.yaml
@@ -58,6 +58,9 @@ spec:
         # TODO: Upstream to openshift/os
         sed -i 's/rhel-9.*-server-ose.*/artifacts/' $(readlink -f src/config/manifest-$(params.variant).yaml)
 
+        # use openvswitch2.17 for 4.12, and temporarily for 4.13 too
+        sed -i 's/openvswitch3.1/openvswitch2.17/' src/config/common-el9.yaml
+
         # tmp fix for replacing version labels in manifest
         sed -i "s/\"4.13\"/\"$(params.version)\"/g" $(readlink -f src/config/manifest-$(params.variant).yaml)
         sed -i "s/\"413\.9./\"$(echo "$(params.version)" | sed 's/\.//')\.9./" $(readlink -f src/config/manifest-$(params.variant).yaml)


### PR DESCRIPTION
4.12 is going to stay on v2.17, while 4.13 is going to switch to v3.1. However, v3.1 is not available in CentOS Stream repos, yet, so composes will temporarily continue to pull in v2.17 with this change.

Fixes current pipelinerun failures.

cc @sherine-k @travier