### PR TITLE
cosa-push-container: Fix tag-latest

### DIFF
--- a/base/batch/cronjobs/okd-coreos-all-4.14-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-all-4.14-create-daily.yaml
@@ -47,7 +47,7 @@ spec:
               - name: ARTIFACTS_IMAGE
                 value: "registry.ci.openshift.org/origin/4.14:artifacts"
               - name: TAG_LATEST
-                value: "false"
+                value: "true"
               - name: CLAIMNAME
                 value: "pipeline-scos-next-pvc"
             resources:

--- a/base/tekton.dev/tasks/cosa-push-container.yaml
+++ b/base/tekton.dev/tasks/cosa-push-container.yaml
@@ -28,9 +28,10 @@ spec:
         set -euxo pipefail
 
         cd /srv/coreos
-        cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name):$(params.tag)-$(uname -m)
+        cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name)
         if [[ "$(params.tag-latest)" == "true" ]]; then
-          cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name)
+          # Add stable tag for import into Prow
+          cosa push-container --authfile=$(workspaces.regcred.path)/.dockerconfigjson --image=$(params.image) $(params.target-registry)/$(params.container-image-name):$(params.tag)-$(uname -m)
         fi
 
   workspaces:

--- a/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
@@ -37,7 +37,7 @@ spec:
     - name: upload-container-images
       value: "true"
     - name: tag-latest
-      value: "false"
+      value: "true"
     - name: upload-bootimages
       value: "true"
     - name: notify-matrix


### PR DESCRIPTION
Somewhat of a misnomer, tag-latest is supposed to tag the image into the stable tag that is auto-imported into Prow.
Fix this is to always tag the version, and only tag into the stable tag when tag-latest == true.