### PR TITLE
cosa-build-baseos: Add --force-nocache flag to cosa build

### DIFF
--- a/base/tekton.dev/tasks/cosa-build-baseos.yaml
+++ b/base/tekton.dev/tasks/cosa-build-baseos.yaml
@@ -42,7 +42,7 @@ spec:
           --aws-config-file=$(workspaces.s3creds.path)/$(params.aws-config-file)
         fi
         cosa fetch
-        cosa build ostree
+        cosa build ostree --force-nocache
 
   workspaces:
     - mountPath: /srv

--- a/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
@@ -12,7 +12,7 @@ spec:
     - name: repo
       value: "https://github.com/openshift/os.git"
     - name: branch
-      value: "master"
+      value: "release-4.13"
     - name: variant
       value: "scos"     
     - name: version

--- a/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-all-4.13-pipelinerun.yaml
@@ -42,6 +42,8 @@ spec:
       value: "true"
     - name: notify-matrix
       value: "true"
+    - name: claimname
+      value: pipeline-scos-stable-pvc
   podTemplate:
     nodeSelector:
        kubernetes.io/hostname: host-192-168-111-83

--- a/environments/moc/pipelineruns/okd-coreos-all-4.14-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-all-4.14-pipelinerun.yaml
@@ -41,6 +41,8 @@ spec:
       value: "true"
     - name: notify-matrix
       value: "true"
+    - name: claimname
+      value: pipeline-scos-next-pvc
   podTemplate:
     nodeSelector:
       kubernetes.io/hostname: host-192-168-111-83

--- a/environments/moc/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
@@ -36,6 +36,8 @@ spec:
       value: "!nStsazaBvZCZQHPWTY:fedoraproject.org"
     - name: matrix-endpoint
       value: 'matrix.org'
+    - name: claimname
+      value: pipeline-scos-stable-pvc
   podTemplate:
     nodeSelector:
        kubernetes.io/hostname: host-192-168-111-83

--- a/environments/moc/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-build-4.13-pipelinerun.yaml
@@ -12,7 +12,7 @@ spec:
     - name: repo
       value: "https://github.com/openshift/os.git"
     - name: branch
-      value: "master"
+      value: "release-4.13"
     - name: variant
       value: "scos"     
     - name: version

--- a/environments/moc/pipelineruns/okd-coreos-build-4.14-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-build-4.14-pipelinerun.yaml
@@ -35,6 +35,8 @@ spec:
       value: "!nStsazaBvZCZQHPWTY:fedoraproject.org"
     - name: matrix-endpoint
       value: 'matrix.org'
+    - name: claimname
+      value: pipeline-scos-next-pvc
   podTemplate:
     nodeSelector:
       kubernetes.io/hostname: host-192-168-111-83


### PR DESCRIPTION
These changes are an attempt to mitigate the fact that we are re-using persistent PVs instead of dynamically creating ephemeral ones on demand.

This is only a stop-gap solution until we use the local storage provisioner for dynamic storage.