### PR TITLE
Remove obsolete note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ All the necessary resources to deploy a generic Tekton pipeline to build CoreOS 
 
 ## Usage in a Kind cluster
 
-Note: This pipeline requires [kvm-device-plugin](https://github.com/cgwalters/kvm-device-plugin) to be installed on the cluster with privileges, which the following commands will deploy. 
-
 For Kind (and possibly other) clusters, execute the following commands:
 
 ```bash


### PR DESCRIPTION
Pre-installing `kvm-device-plugin` on the cluster is not necessary since the merge of #49. It's handled with [1].

[1] https://github.com/okd-project/okd-coreos-pipeline/commit/cf26ebedf2308eeb84011cab3dd9d15702480a79#diff-b74ac5f1846fa9d348ee5750a763da5ff9ded4539a60f9fa071ac22e8da8f07d