### PR TITLE
imagePullPolicy always for steps with non-pinned images

### DIFF
--- a/base/tekton.dev/tasks/cosa-build-baseos.yaml
+++ b/base/tekton.dev/tasks/cosa-build-baseos.yaml
@@ -18,6 +18,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: fetch-and-build-baseos
       resources:
         limits:

--- a/base/tekton.dev/tasks/cosa-build-extensions.yaml
+++ b/base/tekton.dev/tasks/cosa-build-extensions.yaml
@@ -9,6 +9,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: build-extensions-container
       resources:
         limits:

--- a/base/tekton.dev/tasks/cosa-buildextend.yaml
+++ b/base/tekton.dev/tasks/cosa-buildextend.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: buildextend
       resources:
         limits:

--- a/base/tekton.dev/tasks/cosa-generate-release-meta.yaml
+++ b/base/tekton.dev/tasks/cosa-generate-release-meta.yaml
@@ -15,6 +15,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: generate-release-meta
       resources: {}
       script: |

--- a/base/tekton.dev/tasks/cosa-init.yaml
+++ b/base/tekton.dev/tasks/cosa-init.yaml
@@ -18,6 +18,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: prepare-repo
       resources:
         limits:

--- a/base/tekton.dev/tasks/cosa-push-container.yaml
+++ b/base/tekton.dev/tasks/cosa-push-container.yaml
@@ -21,6 +21,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: upload-image
       resources: {}
       script: |

--- a/base/tekton.dev/tasks/cosa-test.yaml
+++ b/base/tekton.dev/tasks/cosa-test.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: build-and-test-qemu
       resources:
         limits:

--- a/base/tekton.dev/tasks/cosa-upload-s3.yaml
+++ b/base/tekton.dev/tasks/cosa-upload-s3.yaml
@@ -18,6 +18,7 @@ spec:
       type: string
   steps:
     - image: 'quay.io/coreos-assembler/coreos-assembler:latest'
+      imagePullPolicy: Always
       name: upload-image
       resources: {}
       script: |

--- a/base/tekton.dev/tasks/rpm-artifacts-copy.yaml
+++ b/base/tekton.dev/tasks/rpm-artifacts-copy.yaml
@@ -9,6 +9,7 @@ spec:
       type: string
   steps:
     - image: $(params.image)
+      imagePullPolicy: Always
       name: copy-rpms
       resources: {}
       script: |


### PR DESCRIPTION
Tekton pods default to the IfNotPresent imagePullPolicy, leading to the possibility of missing updates to the images when they are referred by tag and already pulled by a past execution in the node where a TaskRun pod is scheduled.

This commit sets the imagePullPolicy to Always for the steps using non-pinned images referenced by tag.