### PR TITLE
update 4.16 cronjob to use latest branch

### DIFF
--- a/base/batch/cronjobs/okd-coreos-4.16-prod-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-4.16-prod-create-daily.yaml
@@ -39,7 +39,7 @@ spec:
               - name: SINK_URL
                 value: "http://el-okd-coreos-prod.okd-coreos.svc.cluster.local:8080"
               - name: BRANCH
-                value: "release-4.16"
+                value: "master"
               - name: OKD_VERSION
                 value: "4.16"
               - name: RELEASE_STREAM

--- a/base/batch/cronjobs/okd-coreos-4.17-prod-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-4.17-prod-create-daily.yaml
@@ -39,7 +39,7 @@ spec:
               - name: SINK_URL
                 value: "http://el-okd-coreos-prod.okd-coreos.svc.cluster.local:8080"
               - name: BRANCH
-                value: "release-4.17"
+                value: "master"
               - name: OKD_VERSION
                 value: "4.17"
               - name: RELEASE_STREAM


### PR DESCRIPTION
Updated to release-4.17 since it is in sync with master. we want to continue using 4.17 for the 4.16 builds as well and hopefully we don't need to worry about syncing as scos images will be created by coreos team long term.