### PR TITLE
Use RH mirror to pull Openshift related artifacts

### DIFF
--- a/base/batch/cronjobs/okd-coreos-4.16-prod-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-4.16-prod-create-daily.yaml
@@ -25,7 +25,6 @@ spec:
                     "branch": "${BRANCH}",
                     "version": "${OKD_VERSION}",
                     "release-stream": "${RELEASE_STREAM}",
-                    "rpm-artifacts-image": "${ARTIFACTS_IMAGE}",
                     "tag-latest": "${TAG_LATEST}",
                     "claimname": "${CLAIMNAME}"
                   }
@@ -44,8 +43,6 @@ spec:
                 value: "4.16"
               - name: RELEASE_STREAM
                 value: "stable"
-              - name: ARTIFACTS_IMAGE
-                value: "registry.ci.openshift.org/origin/scos-4.16:artifacts"
               - name: TAG_LATEST
                 value: "true"
               - name: CLAIMNAME

--- a/base/batch/cronjobs/okd-coreos-4.17-prod-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-4.17-prod-create-daily.yaml
@@ -25,7 +25,6 @@ spec:
                     "branch": "${BRANCH}",
                     "version": "${OKD_VERSION}",
                     "release-stream": "${RELEASE_STREAM}",
-                    "rpm-artifacts-image": "${ARTIFACTS_IMAGE}",
                     "tag-latest": "${TAG_LATEST}",
                     "claimname": "${CLAIMNAME}"
                   }
@@ -44,8 +43,6 @@ spec:
                 value: "4.17"
               - name: RELEASE_STREAM
                 value: "next"
-              - name: ARTIFACTS_IMAGE
-                value: "registry.ci.openshift.org/origin/scos-4.17:artifacts"
               - name: TAG_LATEST
                 value: "true"
               - name: CLAIMNAME

--- a/base/batch/cronjobs/okd-coreos-4.18-prod-create-daily.yaml
+++ b/base/batch/cronjobs/okd-coreos-4.18-prod-create-daily.yaml
@@ -25,7 +25,6 @@ spec:
                     "branch": "${BRANCH}",
                     "version": "${OKD_VERSION}",
                     "release-stream": "${RELEASE_STREAM}",
-                    "rpm-artifacts-image": "${ARTIFACTS_IMAGE}",
                     "tag-latest": "${TAG_LATEST}",
                     "claimname": "${CLAIMNAME}"
                   }
@@ -44,8 +43,6 @@ spec:
                 value: "4.18"
               - name: RELEASE_STREAM
                 value: "next"
-              - name: ARTIFACTS_IMAGE
-                value: "registry.ci.openshift.org/origin/scos-4.18:artifacts"
               - name: TAG_LATEST
                 value: "true"
               - name: CLAIMNAME

--- a/base/tekton.dev/pipelines/okd-coreos.yaml
+++ b/base/tekton.dev/pipelines/okd-coreos.yaml
@@ -19,9 +19,6 @@ spec:
     - name: release-stream
       default: "next"
       type: string
-    - default: "registry.ci.openshift.org/origin/4.14:artifacts"
-      name: rpm-artifacts-image
-      type: string
     - name: target-registry
       default: "quay.io/okd"
       type: string
@@ -61,16 +58,6 @@ spec:
       type: string
       default: "an_endpoint"
   tasks:
-    - name: rpm-artifacts-copy
-      params:
-        - name: image
-          value: $(params.rpm-artifacts-image)
-      taskRef:
-        kind: Task
-        name: rpm-artifacts-copy
-      workspaces:
-        - name: ws
-          workspace: shared-workspace
     - name: cosa-init
       params:
         - name: repo
@@ -81,8 +68,6 @@ spec:
           value: $(params.variant)
         - name: version
           value: $(params.version)
-      runAfter:
-        - rpm-artifacts-copy
       taskRef:
         kind: Task
         name: cosa-init

--- a/base/tekton.dev/tasks/cosa-build-extensions.yaml
+++ b/base/tekton.dev/tasks/cosa-build-extensions.yaml
@@ -26,13 +26,13 @@ spec:
 
         cd /srv/coreos
 
-        # The rpms that were extracted from the artifacts image
+        # The rpms that were extracted from the rhel-9-server-ose-rpms repo
         # are not present inside the container used to build the
         # extensions, however `rpm-ostree compose extensions`
         # will try to fetch metadata for all repos listed in
         # both {manifest,extensions}.yaml
         # TODO: Find a more elegant way to do this
-        sed -i 's/- artifacts//' $(readlink -f src/config/manifest-$(params.variant).yaml)
+        sed -i 's/- rhel-9-server-ose-rpms//' $(readlink -f src/config/manifest-$(params.variant).yaml)
 
         # build with the CentOS image rather than the ubi image. Using the ubi image is acceptable as long as we don't
         # pull in RHEL content, but basing it on CentOS brings consistency with other images.

--- a/base/tekton.dev/tasks/cosa-init.yaml
+++ b/base/tekton.dev/tasks/cosa-init.yaml
@@ -31,6 +31,7 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
+        rm -rf /workspace/*
         mkdir -p /workspace/coreos
         cd /workspace/coreos
 
@@ -57,20 +58,31 @@ spec:
         fi
 
         # TODO: Upstream to openshift/os
-        # Get oc and hypershift from the yum repo in the artifacts image,
-        # instead of the rhel ose repo.
-        sed -i 's/rhel-9.*-server-ose.*/artifacts/' $(readlink -f src/config/manifest-$(params.variant).yaml)
+        # Get oc and hypershift from RedHat's internal mirror repo, instead of the rhel ose repo.
+        sed -i 's/rhel-9.*-server-ose.*/rhel-9-server-ose-rpms/' $(readlink -f src/config/manifest-$(params.variant).yaml)
         cat <<EOF >> src/config/c9s.repo
 
-        [artifacts]
-        name=OKD RPM artifacts
-        baseurl=file:///workspace/coreos/rpms/
+        [rhel-9-server-ose-rpms]
+        baseurl=https://mirror.openshift.com/enterprise/reposync/$(params.version)/rhel-9-server-ose-rpms
+        includepkgs=openshift-* ose-aws-ecr-* ose-azure-acr-* ose-gcp-gcr-*
+        username=$MIRROR_USER
+        password=$MIRROR_PASS
         repo_gpgcheck=0
         gpgcheck=0
         enabled=1
 
         EOF
-
+      env:
+      - name: MIRROR_USER
+        valueFrom:
+          secretKeyRef:
+            name: ose-mirror-secret
+            key: mirror-user
+      - name: MIRROR_PASS
+        valueFrom:
+          secretKeyRef:
+            name: ose-mirror-secret
+            key: mirror-pass
   workspaces:
     - mountPath: /workspace
       name: ws

--- a/base/tekton.dev/tasks/kustomization.yaml
+++ b/base/tekton.dev/tasks/kustomization.yaml
@@ -9,5 +9,4 @@ resources:
   - cosa-test.yaml
   - cosa-upload-s3.yaml
   - cosa-generate-release-meta.yaml
-  - rpm-artifacts-copy.yaml
   - notify-matrix.yaml

--- a/base/triggers.tekton.dev/triggerbindings/okd-coreos-prod.yaml
+++ b/base/triggers.tekton.dev/triggerbindings/okd-coreos-prod.yaml
@@ -10,8 +10,6 @@ spec:
     value: $(body.params.version)
   - name: release-stream
     value: $(body.params.release-stream)
-  - name: rpm-artifacts-image
-    value: $(body.params.rpm-artifacts-image)
   - name: tag-latest
     value: $(body.params.tag-latest)
   - name: claimname

--- a/base/triggers.tekton.dev/triggertemplates/okd-coreos-prod.yaml
+++ b/base/triggers.tekton.dev/triggertemplates/okd-coreos-prod.yaml
@@ -14,8 +14,6 @@ spec:
     default: "4.13"
   - name: release-stream
     default: "stable"
-  - name: rpm-artifacts-image
-    default: "registry.ci.openshift.org/origin/4.13:artifacts"
   - name: target-registry
     default: "quay.io/okd"
   - name: baseos-container-image-name
@@ -65,8 +63,6 @@ spec:
           value: $(tt.params.version)
         - name: release-stream
           value: $(tt.params.release-stream)
-        - name: rpm-artifacts-image
-          value: $(tt.params.rpm-artifacts-image)
         - name: target-registry
           value: $(tt.params.target-registry)
         - name: baseos-container-image-name

--- a/environments/kind/pipelineruns/okd-coreos-4.16-dev-pipelinerun.yaml
+++ b/environments/kind/pipelineruns/okd-coreos-4.16-dev-pipelinerun.yaml
@@ -19,8 +19,6 @@ spec:
       value: "4.16"
     - name: release-stream
       value: "next"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.16:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/kind/pipelineruns/okd-coreos-4.17-dev-pipelinerun.yaml
+++ b/environments/kind/pipelineruns/okd-coreos-4.17-dev-pipelinerun.yaml
@@ -19,8 +19,6 @@ spec:
       value: "4.17"
     - name: release-stream
       value: "next"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.17:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/kind/pipelineruns/okd-coreos-4.18-dev-pipelinerun.yaml
+++ b/environments/kind/pipelineruns/okd-coreos-4.18-dev-pipelinerun.yaml
@@ -19,8 +19,6 @@ spec:
       value: "4.18"
     - name: release-stream
       value: "next"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.18:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/moc/pipelineruns/okd-coreos-4.16-prod-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-4.16-prod-pipelinerun.yaml
@@ -17,8 +17,6 @@ spec:
       value: "okd-c9s"
     - name: version
       value: "4.16"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.16:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/moc/pipelineruns/okd-coreos-4.17-prod-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-4.17-prod-pipelinerun.yaml
@@ -17,8 +17,6 @@ spec:
       value: "okd-c9s"
     - name: version
       value: "4.17"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.17:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/environments/moc/pipelineruns/okd-coreos-4.18-prod-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-coreos-4.18-prod-pipelinerun.yaml
@@ -17,8 +17,6 @@ spec:
       value: "okd-c9s"
     - name: version
       value: "4.18"
-    - name: rpm-artifacts-image
-      value: "registry.ci.openshift.org/origin/scos-4.18:artifacts"
     - name: target-registry
       value: "quay.io/okd"
     - name: baseos-container-image-name

--- a/overlays/okd-images/kustomization.yaml
+++ b/overlays/okd-images/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
   - ../../base/image.openshift.io/imagestreams/centos
   - ../../base/image.openshift.io/imagestreams/coreos-assembler
   - ../../base/image.openshift.io/imagestreams/kvm-device-plugin
-  - ../../base/image.openshift.io/imagestreams/okd-artifacts
   - ../../base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin-image-puller


### PR DESCRIPTION
The OKD operator builds don't produce the artifacts image anymore. This now comes from the RH mirror. In the future we have to explore the possibility of it coming from the public coreos CI composes, but for now this is behind a token.